### PR TITLE
Prevent manifest merger failure

### DIFF
--- a/easyrs/src/main/AndroidManifest.xml
+++ b/easyrs/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.github.silvaren.easyrs.tools">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    
+    <application />
 
 </manifest>


### PR DESCRIPTION
This is to prevent Gradle sync error.

```
ERROR: Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:14:9-36
	is also present at [io.github.silvaren:easyrs:0.5.3] AndroidManifest.xml:12:9-35 value=(true).
	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:12:5-27:19 to override.
```